### PR TITLE
Wire up undo and improve immutability with stricter types

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,6 +17,7 @@
     "copy-webpack-plugin": "^9.0.1",
     "graphql": "^15.5.3",
     "graphql-request": "^3.5.0",
+    "immutability-helper": "^3.1.1",
     "next": "^11.0.0",
     "prettier": "^2.4.1",
     "react": "^17.0.1",

--- a/packages/web/src/app/components/editor/Editor.tsx
+++ b/packages/web/src/app/components/editor/Editor.tsx
@@ -48,34 +48,28 @@ const Editor = ({ x, y, closeModal }: EditorProps) => {
     x: number,
     y: number,
     d: Pixels,
-    checked: Record<string, boolean>
+    checked: Record<string, boolean> = {}
   ) => {
-    const key = `${x},${y}`;
+    if (x < 0 || x >= MAX) return d;
+    if (y < 0 || y >= MAX) return d;
 
+    const key = `${x},${y}`;
     // If we've already checked this pixel don't check again
     if (checked[key]) return d;
 
     // if this is no longer the same color stop checking
-    if (pixels[x][y] !== startColor) return d;
+    if (d[x][y] !== startColor) return d;
 
     // TODO: set up a linter to prevent mutating arguments?
 
     // paint this pixels color
     d = update(d, { [x]: { [y]: { $set: color } } });
 
-    // Find Neighbors and add them to the stack
-    if (x + 1 < MAX) {
-      d = paintNeighbors(color, startColor, x + 1, y, d, checked);
-    }
-    if (x - 1 >= 0) {
-      d = paintNeighbors(color, startColor, x - 1, y, d, checked);
-    }
-    if (y + 1 < MAX) {
-      d = paintNeighbors(color, startColor, x, y + 1, d, checked);
-    }
-    if (y - 1 >= 0) {
-      d = paintNeighbors(color, startColor, x, y - 1, d, checked);
-    }
+    // paint each adjacent pixel
+    d = paintNeighbors(color, startColor, x + 1, y, d, checked);
+    d = paintNeighbors(color, startColor, x - 1, y, d, checked);
+    d = paintNeighbors(color, startColor, x, y + 1, d, checked);
+    d = paintNeighbors(color, startColor, x, y - 1, d, checked);
 
     // Since we've just checked this one, make sure we don't check it again
     checked[key] = true;
@@ -112,9 +106,9 @@ const Editor = ({ x, y, closeModal }: EditorProps) => {
       setActiveColor(palette[pixels[x][y]]);
       setActiveTool(prevTool);
     } else if (activeTool == Tool.BUCKET) {
-      const d = paintNeighbors(activeColor, pixels[x][y], x, y, pixels, {});
-      setPixels(d);
-      addPixelsToHistory(d);
+      const newPixels = paintNeighbors(activeColor, pixels[x][y], x, y, pixels);
+      setPixels(newPixels);
+      addPixelsToHistory(newPixels);
     }
   };
 

--- a/packages/web/src/app/components/editor/EditorPreview.tsx
+++ b/packages/web/src/app/components/editor/EditorPreview.tsx
@@ -1,9 +1,9 @@
-import useEditor from '@app/hooks/use-editor';
+import useEditor, { Pixels } from '@app/hooks/use-editor';
 import React from 'react';
 import CanvasTile from '../canvas/CanvasTile';
 
 interface EditorPreviewProps {
-  pixels: number[][];
+  pixels: Pixels;
   columns: number[];
   rows: number[];
   x: number;
@@ -16,7 +16,6 @@ const tileStyle = {
 };
 
 const EditorPreview = ({ pixels, x, y, columns, rows }: EditorPreviewProps) => {
-  console.log(pixels);
   const { palette } = useEditor();
 
   return (

--- a/packages/web/src/app/hooks/use-editor.ts
+++ b/packages/web/src/app/hooks/use-editor.ts
@@ -1,15 +1,17 @@
 import {
   createTile,
   getSignatureForTypedData,
-  submitTx,
-} from "@app/features/Forwarder";
-import getJsonRpcProvider from "@app/features/getJsonRpcProvider";
-import useStore, { Tool } from "@app/features/State";
-import { useWallet } from "@gimmixorg/use-wallet";
-import PALETTES from "src/constants/Palettes";
+  submitTx
+} from '@app/features/Forwarder';
+import getJsonRpcProvider from '@app/features/getJsonRpcProvider';
+import useStore, { Tool } from '@app/features/State';
+import { useWallet } from '@gimmixorg/use-wallet';
+import PALETTES from 'src/constants/Palettes';
+
+export type Pixels = readonly (readonly number[])[];
 
 interface SetTileProps {
-  pixels: number[][];
+  pixels: Pixels;
   x: number;
   y: number;
 }
@@ -51,24 +53,24 @@ const useEditor = () => {
 
     switch (activeTool) {
       case Tool.BRUSH:
-        return "url(/static/px-icon-pencil.svg) 0 11, pointer";
+        return 'url(/static/px-icon-pencil.svg) 0 11, pointer';
       case Tool.BUCKET:
-        return "url(/static/px-icon-bucket.svg) 0 11, pointer";
+        return 'url(/static/px-icon-bucket.svg) 0 11, pointer';
       case Tool.EYEDROPPER:
-        return "url(/static/px-icon-eyedropper.svg) 4 11, pointer";
+        return 'url(/static/px-icon-eyedropper.svg) 4 11, pointer';
     }
   };
 
   const setTile = async ({ x, y, pixels }: SetTileProps) => {
-    if (!provider || !account) return alert("Not signed in.");
+    if (!provider || !account) return alert('Not signed in.');
 
     let transposed = transpose(pixels);
     let flattened = transposed.flat();
-    let outputPixels = "0x";
+    let outputPixels = '0x';
     for (let i = 0; i < flattened.length; i += 2) {
       let d = `${((flattened[i] << 4) | flattened[i + 1])
         .toString(16)
-        .padStart(2, "0")}`;
+        .padStart(2, '0')}`;
       outputPixels += d;
     }
     console.log(outputPixels);
@@ -96,7 +98,7 @@ const useEditor = () => {
     setActiveColor,
     setActiveTool,
     setTile,
-    getActiveCursor,
+    getActiveCursor
   };
 };
 

--- a/packages/web/yarn.lock
+++ b/packages/web/yarn.lock
@@ -3836,6 +3836,11 @@ immer@^9.0.3:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
   integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
 
+immutability-helper@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-3.1.1.tgz#2b86b2286ed3b1241c9e23b7b21e0444f52f77b7"
+  integrity sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ==
+
 import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"


### PR DESCRIPTION
I started wiring up some undo functionality, but quickly realized that we're mutating the original `pixels` state array rather than creating a new array when updating pixels. To fix, I added stricter types (specifically `readonly`) then fixed the type errors using `immutability-helper` (recommended by React team) for updating pixels.

To wire up the undo, I just track a history of pixels painted to the board and just revert to the next recent history item. We can artificially limit the history/undo length, but I figured I'd keep it ~unlimited until it becomes problematic.

Undo/history is debounced because "painting" (click and drag) was adding _lots_ of individual entries and it's very tiresome to undo these without grouping these operations. Debounce was quick/easy to reach for, but we could probably do something smarter here if we wanted to put more time into it.