### PR TITLE
redo peek, reveal 4px

### DIFF
--- a/packages/web/src/app/components/canvas/CanvasTile.tsx
+++ b/packages/web/src/app/components/canvas/CanvasTile.tsx
@@ -106,7 +106,7 @@ const CanvasTile = ({
     <div id={`tile-${x}-${y}`} className="tile" onClick={onClick} style={style}>
       {tile?.svg && (
         <img
-          src={`/api/tiles/terramasu/${x}/${y}/img`}
+          src={`/api/tiles/terramasu/${x}/${y}/svg`}
           width="100"
           height="100"
           className="tile-image"

--- a/packages/web/src/app/components/editor/Editor.tsx
+++ b/packages/web/src/app/components/editor/Editor.tsx
@@ -326,6 +326,9 @@ const Editor = ({
                     left: `${100 * offsetX}%`,
                     top: `${100 * offsetY}%`
                   }}
+                  onError={(event) => {
+                    event.currentTarget.style.display = 'none';
+                  }}
                 />
               ))}
             </>

--- a/packages/web/src/app/components/editor/Editor.tsx
+++ b/packages/web/src/app/components/editor/Editor.tsx
@@ -321,7 +321,7 @@ const Editor = ({
               {peek.map(({ offsetX, offsetY }) => (
                 <img
                   key={`${offsetX},${offsetY}`}
-                  src={`/api/tiles/terramasu/${x + offsetX}/${y + offsetY}/img`}
+                  src={`/api/tiles/terramasu/${x + offsetX}/${y + offsetY}/svg`}
                   style={{
                     left: `${100 * offsetX}%`,
                     top: `${100 * offsetY}%`

--- a/packages/web/src/app/components/editor/Editor.tsx
+++ b/packages/web/src/app/components/editor/Editor.tsx
@@ -4,7 +4,6 @@ import useEditor, { Pixels } from '@app/hooks/use-editor';
 import { Tool } from '@app/features/State';
 import Icon from './Icon';
 import EditorPreview from './EditorPreview';
-import TileSVG from '../canvas/TileSVG';
 import update from 'immutability-helper';
 import { useDebouncedCallback } from 'use-debounce';
 import { getSVGFromPixels } from '@app/features/TileUtils';
@@ -20,10 +19,22 @@ interface EditorProps {
 }
 
 const MAX = 32;
-const PIXEL_SIZE = 18;
+const PIXEL_SIZE = 16;
 
 const columns = Array.from(Array(MAX).keys());
 const rows = Array.from(Array(MAX).keys());
+
+type TilePeek = { offsetX: number; offsetY: number };
+const peek: TilePeek[] = [];
+for (let offsetY = -1; offsetY <= 1; offsetY++) {
+  for (let offsetX = -1; offsetX <= 1; offsetX++) {
+    if (offsetX === 0 && offsetY === 0) {
+      // exclude the tile we're drawing
+      continue;
+    }
+    peek.push({ offsetX, offsetY });
+  }
+}
 
 const EMPTY: Pixels = columns.map(() => rows.map(() => 13));
 
@@ -271,123 +282,55 @@ const Editor = ({
   return (
     <div className="editor">
       <div className="canvas-peek">
-        <div
-          className="canvas"
-          draggable={false}
-          onPointerDown={(e) => {
-            setDrawing(true);
-          }}
-          onPointerUp={() => setDrawing(false)}
-          onMouseLeave={() => setDrawing(false)}
-          onPointerLeave={() => setDrawing(false)}
-        >
-          {columns.map((y) => {
-            return rows.map((x) => {
-              return (
-                <div
-                  id={`${x}_${y}`}
-                  key={`${x}_${y}`}
-                  className="box"
-                  style={{ backgroundColor: palette[pixels?.[x]?.[y]] }}
-                  onPointerEnter={(e) => onMouseEnter(e, x, y)}
-                  onMouseDown={(e) => onMouseEnter(e, x, y)}
-                  onMouseOver={(e) => onMouseEnter(e, x, y)}
-                  onTouchMove={(e) => {
-                    touchEnter(e);
+        <div className="canvas-neighbors">
+          <div
+            className="canvas"
+            draggable={false}
+            onPointerDown={(e) => {
+              setDrawing(true);
+            }}
+            onPointerUp={() => setDrawing(false)}
+            onMouseLeave={() => setDrawing(false)}
+            onPointerLeave={() => setDrawing(false)}
+          >
+            {columns.map((y) => {
+              return rows.map((x) => {
+                return (
+                  <div
+                    id={`${x}_${y}`}
+                    key={`${x}_${y}`}
+                    className="box"
+                    style={{ backgroundColor: palette[pixels?.[x]?.[y]] }}
+                    onPointerEnter={(e) => onMouseEnter(e, x, y)}
+                    onMouseDown={(e) => onMouseEnter(e, x, y)}
+                    onMouseOver={(e) => onMouseEnter(e, x, y)}
+                    onTouchMove={(e) => {
+                      touchEnter(e);
+                    }}
+                    onTouchStart={(e) => {
+                      touchEnter(e);
+                    }}
+                  ></div>
+                );
+              });
+            })}
+          </div>
+
+          {!hideMinimap ? (
+            <>
+              {peek.map(({ offsetX, offsetY }) => (
+                <img
+                  key={`${offsetX},${offsetY}`}
+                  src={`/api/tiles/terramasu/${x + offsetX}/${y + offsetY}/img`}
+                  style={{
+                    left: `${100 * offsetX}%`,
+                    top: `${100 * offsetY}%`
                   }}
-                  onTouchStart={(e) => {
-                    touchEnter(e);
-                  }}
-                ></div>
-              );
-            });
-          })}
+                />
+              ))}
+            </>
+          ) : null}
         </div>
-
-        {!hideMinimap && (
-          <>
-            <div className="peek-north">
-              <TileSVG
-                x={x - 1}
-                y={y - 1}
-                viewbox={'30 29.5 32 32'}
-                style={{
-                  height: `${PIXEL_SIZE * 2}px`,
-                  width: `${PIXEL_SIZE * 2}px`
-                }}
-                svgWidth={`${PIXEL_SIZE * 32}px`}
-              ></TileSVG>
-              <TileSVG
-                x={x}
-                y={y - 1}
-                viewbox={'0 29.5 32 32'}
-                style={{
-                  height: `${PIXEL_SIZE * 2}px`,
-                  width: `${PIXEL_SIZE * 32}px`
-                }}
-              ></TileSVG>
-              <TileSVG
-                x={x + 1}
-                y={y - 1}
-                viewbox={'0 29.5 32 32'}
-                style={{
-                  height: `${PIXEL_SIZE * 2}px`,
-                  width: `${PIXEL_SIZE * 2}px`
-                }}
-                svgWidth={`${PIXEL_SIZE * 32}px`}
-              ></TileSVG>
-            </div>
-
-            <div className="peek-south">
-              <TileSVG
-                x={x - 1}
-                y={y + 1}
-                viewbox={'30 -0.5 32 32'}
-                style={{
-                  height: `${PIXEL_SIZE * 2}px`,
-                  width: `${PIXEL_SIZE * 2}px`
-                }}
-                svgHeight={`${PIXEL_SIZE * 32}px`}
-              ></TileSVG>
-              <TileSVG
-                x={x}
-                y={y + 1}
-                viewbox={'0 -0.5 32 32'}
-                style={{
-                  height: `${PIXEL_SIZE * 2}px`,
-                  width: `${PIXEL_SIZE * 32}px`
-                }}
-              ></TileSVG>
-              <TileSVG
-                x={x + 1}
-                y={y + 1}
-                viewbox={'0 -0.5 32 32'}
-                style={{
-                  height: `${PIXEL_SIZE * 2}px`,
-                  width: `${PIXEL_SIZE * 2}px`
-                }}
-                svgHeight={`${PIXEL_SIZE * 32}px`}
-              ></TileSVG>
-            </div>
-
-            <div className="peek-west">
-              <TileSVG
-                x={x - 1}
-                y={y}
-                viewbox={'30 -0.5 32 32'}
-                svgHeight={`${PIXEL_SIZE * 32}px`}
-              ></TileSVG>
-            </div>
-            <div className="peek-east">
-              <TileSVG
-                x={x + 1}
-                y={y}
-                viewbox={'0 -0.5 32 32'}
-                svgHeight={`${PIXEL_SIZE * 32}px`}
-              ></TileSVG>
-            </div>
-          </>
-        )}
       </div>
 
       <div className="canvas-aside-left">
@@ -592,30 +535,19 @@ const Editor = ({
         }
 
         .canvas-peek {
-          display: ${!hideMinimap ? 'grid' : 'block'};
-          grid-template-columns: 36px auto 36px;
-          grid-template-rows: 36px auto 31px;
-          gap: 0px 0px;
-          grid-template-areas:
-            'peek-north peek-north peek-north'
-            'peek-west canvas peek-east'
-            'peek-south peek-south peek-south';
+          width: ${PIXEL_SIZE * (MAX + 8)}px;
+          height: ${PIXEL_SIZE * (MAX + 8)}px;
+          padding: ${PIXEL_SIZE * 4}px;
+          overflow: hidden;
           background: #333;
         }
-        .peek-north {
-          grid-area: peek-north;
-          display: flex;
+        .canvas-neighbors {
+          position relative;
         }
-        .peek-south {
-          grid-area: peek-south;
-          display: flex;
-          margin-top: -4px;
-        }
-        .peek-west {
-          grid-area: peek-west;
-        }
-        .peek-east {
-          grid-area: peek-east;
+        .canvas-neighbors > img {
+          position: absolute;
+          width: 100%;
+          height: 100%;
         }
 
         .preview-minimap {

--- a/packages/web/src/pages/api/tiles/[canvas]/[x]/[y]/img.ts
+++ b/packages/web/src/pages/api/tiles/[canvas]/[x]/[y]/img.ts
@@ -20,6 +20,8 @@ const api: NextApiHandler = async (req, res) => {
     `
   );
 
+  if (!tile) return res.status(404).end();
+
   const sizeParam = parseInt(req.query.size as string);
   let image;
 

--- a/packages/web/src/pages/api/tiles/[canvas]/[x]/[y]/svg.ts
+++ b/packages/web/src/pages/api/tiles/[canvas]/[x]/[y]/svg.ts
@@ -1,0 +1,30 @@
+import { NextApiHandler } from 'next';
+import sharp from 'sharp';
+import { gql, request } from 'graphql-request';
+import { generateTokenID } from '@app/features/TileUtils';
+import { GRAPH_URL } from '@app/features/AddressBook';
+
+const api: NextApiHandler = async (req, res) => {
+  const tokenId = generateTokenID(
+    parseInt(req.query.x as string),
+    parseInt(req.query.y as string)
+  );
+  const { tile } = await request(
+    GRAPH_URL,
+    gql`
+      {
+        tile(id: ${tokenId}) {
+          svg
+        }
+      }
+    `
+  );
+
+  if (!tile) return res.status(404).end();
+
+  res.setHeader('Content-Type', 'image/svg+xml');
+  res.setHeader('Cache-Control', 'public, s-max-age=31536000');
+  return res.send(tile.svg);
+};
+
+export default api;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/508855/142807001-56c989ca-65cc-48a4-854c-7c898b1bc7ba.png)

I was seeing issues with the peek on my tile showing the wrong neighbor:
![image](https://user-images.githubusercontent.com/508855/142808596-210f5924-35d8-4df8-8c13-c4aa48925cd7.png)
![image](https://user-images.githubusercontent.com/508855/142808601-a226c43e-3f8b-4b5b-9bb7-90a47cfb4ea0.png)

This PR reworks how the peek is done by displaying the neighboring tiles in their full glory, but "cropping" the visible portion to only the tile size + padding (originally 2 pixels, now 4 pixels).

Because I increased the peek to 4 pixels, I needed to decrease the overall pixel size so that the editor still fit in the same ~area on the screen as before without flowing off the screen.

I also swapped to using SVG with each `<img>` instead of PNG ones, saving the SVG->PNG conversion step and improving load times (especially on local) and performance.