### PR TITLE
rework editor pixels state, history, and caching

### DIFF
--- a/packages/web/src/app/components/editor/usePixels.tsx
+++ b/packages/web/src/app/components/editor/usePixels.tsx
@@ -23,16 +23,14 @@ export const usePixels = (x: number, y: number) => {
   );
 
   const [pixels, setPixelsState] = useState<Pixels>(
-    pixelsHistory ? pixelsHistory[0] : emptyTile
+    pixelsHistory?.[0] || emptyTile
   );
 
   const addPixelsToHistory = useDebouncedCallback((newPixels: Pixels) => {
-    console.log('adding pixels to history');
     setPixelsHistory([newPixels, ...(pixelsHistory || [emptyTile])]);
   }, 500);
 
   const setPixels = (newPixels: Pixels) => {
-    console.log('setting pixels');
     setPixelsState(newPixels);
     addPixelsToHistory(newPixels);
   };

--- a/packages/web/src/app/components/editor/usePixels.tsx
+++ b/packages/web/src/app/components/editor/usePixels.tsx
@@ -1,0 +1,49 @@
+import { useState, useCallback } from 'react';
+import { gzipSync, gunzipSync } from 'zlib';
+import { Pixels } from '@app/hooks/use-editor';
+import { useDebouncedCallback } from 'use-debounce';
+import { useLocalStorage } from 'react-use';
+import { EXQUISITE_LAND_CONTRACT_ADDRESS } from '../../features/AddressBook';
+
+const tileSize = 32;
+const tileColumns = Array.from(Array(tileSize).keys());
+const tileRows = Array.from(Array(tileSize).keys());
+const emptyTile: Pixels = tileColumns.map(() => tileRows.map(() => 13));
+
+const serializer = <T,>(value: T): string =>
+  gzipSync(JSON.stringify(value)).toString('base64');
+const deserializer = <T,>(value: string): T =>
+  JSON.parse(gunzipSync(Buffer.from(value, 'base64')).toString());
+
+export const usePixels = (x: number, y: number) => {
+  const [pixelsHistory, setPixelsHistory] = useLocalStorage<Pixels[]>(
+    `pixels:v1:${EXQUISITE_LAND_CONTRACT_ADDRESS}:${x},${y}`,
+    [emptyTile],
+    { raw: false, serializer, deserializer }
+  );
+
+  const [pixels, setPixelsState] = useState<Pixels>(
+    pixelsHistory ? pixelsHistory[0] : emptyTile
+  );
+
+  const addPixelsToHistory = useDebouncedCallback((newPixels: Pixels) => {
+    console.log('adding pixels to history');
+    setPixelsHistory([newPixels, ...(pixelsHistory || [emptyTile])]);
+  }, 500);
+
+  const setPixels = (newPixels: Pixels) => {
+    console.log('setting pixels');
+    setPixelsState(newPixels);
+    addPixelsToHistory(newPixels);
+  };
+
+  const undo = () => {
+    const [_pixels, ...prevPixelsHistory] = pixelsHistory || [emptyTile];
+    setPixelsHistory(prevPixelsHistory);
+    setPixelsState(prevPixelsHistory[0] || emptyTile);
+  };
+
+  const canUndo = pixelsHistory && pixelsHistory.length > 0;
+
+  return { pixels, setPixels, undo, canUndo };
+};


### PR DESCRIPTION
This moves editor pixels state management to its own hook and improves on it in the following ways:
- history is stored in localStorage, so that you can reload the page and restore what you were working on, including undo
- localStorage values are gzipped to reduce chance of running into 5mb storage limits
- clears are now considered an entry in history (all white pixels) rather than clearing the history
- cache key uses contract address and an incrementing version number to help invalidate cache across contract deploys and schema changes