### PR TITLE
swap out ENS API

### DIFF
--- a/packages/discord/src/app/components/CachedENSName.tsx
+++ b/packages/discord/src/app/components/CachedENSName.tsx
@@ -4,7 +4,7 @@ import useSWR from 'swr';
 const CachedENSName = ({ address }: { address?: string }) => {
   const { data } = useSWR<{ name: string }>(
     address
-      ? `https://exquisite.land/api/ens-name?address=${address.toLowerCase()}`
+      ? `https://api.ensideas.com/ens/resolve/${encodeURIComponent(address)}`
       : null,
     (url: string) => fetch(url).then((res) => res.json())
   );

--- a/packages/web/src/app/components/CachedENSName.tsx
+++ b/packages/web/src/app/components/CachedENSName.tsx
@@ -3,7 +3,9 @@ import useSWR from 'swr';
 
 const CachedENSName = ({ address }: { address?: string }) => {
   const { data } = useSWR<{ name: string }>(
-    address ? `/api/ens-name?address=${address.toLowerCase()}` : null,
+    address
+      ? `https://api.ensideas.com/ens/resolve/${encodeURIComponent(address)}`
+      : null,
     (url: string) => fetch(url).then((res) => res.json())
   );
   if (!data) return null;


### PR DESCRIPTION
This API endpoint is heavily cached for 24 hours. This should reduce load on the infura node.